### PR TITLE
#163684270 User View All Offices REST Endpoint

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,8 +1,17 @@
-from flask import Flask
+from flask import Flask, make_response, jsonify
 # Setup Models
 from .v1 import models
 # Import blueprint - contain routes handling interaction between view and models
 from .v1.views import version_1
+
+
+# Error Handler Method
+def page_not_found(e):
+    error_response = {
+        "error": "404 ERROR:PAGE NOT FOUND",
+        "status": 404
+    }
+    return make_response(jsonify(error_response))
 
 
 # configure app prerequisites
@@ -11,5 +20,7 @@ def create_app():
     app = Flask(__name__)
     #  Register  blueprints in app instance creation
     app.register_blueprint(version_1)
+    # Error Handler for error message 404
+    app.register_error_handler(404, page_not_found)
     # Return application context
     return app

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -11,7 +11,7 @@ def page_not_found(e):
         "error": "404 ERROR:PAGE NOT FOUND",
         "status": 404
     }
-    return make_response(jsonify(error_response))
+    return make_response(jsonify(error_response), 404)
 
 
 # configure app prerequisites

--- a/api/tests/__init__.py
+++ b/api/tests/__init__.py
@@ -23,7 +23,7 @@ class BaseTestCase(unittest.TestCase):
         }
 
     def tearDown(self):
-        # Reset Data Structs
+        # Reset Data Structs after tests back to empty lists
         models.offices = []
         models.parties = []
 

--- a/api/tests/test_offices_endpoint.py
+++ b/api/tests/test_offices_endpoint.py
@@ -17,7 +17,6 @@ class OfficeEndpointsTestCase(BaseTestCase):
             }],
             'status': 201
         }
-        # Assert - (expected,actual)
         assert response.status_code == 201, "Should Return a 201 HTTP Status Code Response:Created Successfully"
         assert expected_response_json == response.json
 
@@ -28,29 +27,38 @@ class OfficeEndpointsTestCase(BaseTestCase):
                                         # Missing type key
                                         'name': 'Permanent Secretary'
                                     })
-        assert 400 == response.status_code, "Should Return a 400 HTTP Status Code Response:Bad Request"
+        assert response.status_code == 400, "Should Return a 400 HTTP Status Code Response:Bad Request"
         # Should return error message
         assert "BAD REQUEST" in str(response.json), "Should return bad request response"
 
     def test_view_all_offices(self):
         """Tests GET Http method request on /offices endpoint"""
-        # # Post, create an office first
-        # self.client.post('/offices', json=self.office)
-        # # Retrieve the office
-        # response = self.client.get('/offices')
-        # # Assert - (expected,actual)
-        # assert 200 == response.status_code, "Should Return a 200 HTTP Status Code Response:Success"
-        # # Converts to string
-        # assert json.dumps({'data': [self.office]}) in str(response.data)
-        pass
+        # Post, create an office first
+        self.client.post('api/v1/offices', data=json.dumps(self.office))
+        # Retrieve the office
+        response = self.client.get('api/v1/offices')
+        assert response.status_code == 200, "Should Return a 200 HTTP Status Code Response:Success"
+        expected_response_json = {
+            "data": [{
+                "id": 1,
+                'type': 'Senior',
+                'name': 'Permanent Secretary'
+            }],
+            "status": 200
+        }
+        # Converts to string
+        assert expected_response_json == response.json
 
     def test_view_all_offices_bad_request(self):
         """Tests malformed GET Http method request on /office endpoint"""
-        # response = self.client.get('/ofices')
-        # assert 404 == response.status, "Should Return a 404 HTTP Status Code Response:Not Found"
-        # # Should return error message
-        # assert "Not Found" in str(response.error), "Should return resource not found response"
-        pass
+        response = self.client.get('api/v1/ofices')
+        assert response.status_code == 404, "Should Return a 404 HTTP Status Code Response:Resource Not Found"
+        # Should return error message
+        expected_json_resp = {
+            "error": "404 ERROR:PAGE NOT FOUND",
+            "status": 404
+        }
+        assert expected_json_resp == response.json
 
     def test_view_specific_office(self):
         """Tests GET Http method request on /office/{:id} endpoint"""

--- a/api/tests/test_parties_endpoint.py
+++ b/api/tests/test_parties_endpoint.py
@@ -118,3 +118,14 @@ class PartiesEndpointsTestCase(BaseTestCase):
         }
         # Should return error message
         assert expected_response_json == response.json, "Should return [] empty list"
+
+    def test_view_all_political_parties_wrong_path(self):
+        """Tests malformed GET Http method request on /parties/ endpoint"""
+        response = self.client.get('api/v1/partis')
+        assert response.status_code == 404, "Should Return a 404 HTTP Status Code Response:Resource Not Found"
+        expected_json_resp = {
+            "error": "404 ERROR:PAGE NOT FOUND",
+            "status": 404
+        }
+        # Should return error message
+        assert expected_json_resp == response.json, "Should return not found Response"

--- a/api/v1/models.py
+++ b/api/v1/models.py
@@ -4,18 +4,16 @@ offices = []
 
 
 class PartiesModel:
-    def __init__(self):
+    def __init__(self, party=None):
         # Initialise DT inside model
         self.parties = parties
-        self.party = None
+        self.party = party
 
-    def create_political_party(self, party):
+    def create_political_party(self):
         """A function that facilitates creation of a political party and appending to a data structure
            @:return the created party name with success message
         """
         # Extract data from party dict
-        # Created Party as dict
-        self.party = party
         created_party = {
             # Id increments on length of list
             "id": len(parties) + 1,
@@ -33,7 +31,7 @@ class PartiesModel:
 
 
 class OfficesModel:
-    def __init__(self, office):
+    def __init__(self, office=None):
         self.offices = offices
         self.office = office
 
@@ -54,3 +52,6 @@ class OfficesModel:
         offices.append(created_office)
         # Return assigned id response when office successfully created
         return created_office['id']
+
+    def get_all_government_offices(self):
+        return self.offices

--- a/api/v1/views.py
+++ b/api/v1/views.py
@@ -18,7 +18,7 @@ def api_parties():
         # Checks keys exist in given dict
         if {'name', 'hqAddress', 'logoUrl'} <= set(party):
             # Create Party Model instance and add Party to list
-            gen_id = PartiesModel().create_political_party(party)
+            gen_id = PartiesModel(party).create_political_party()
             if gen_id:
                 # successful response
                 response_body = {
@@ -28,6 +28,7 @@ def api_parties():
                         "name": party['name']
                     }]
                 }
+                # Successful
                 return make_response(jsonify(response_body), 201)
         else:
             # Missing data bad request response
@@ -36,6 +37,7 @@ def api_parties():
                 "status": 400,
                 "error": "400 ERROR:BAD REQUEST,Missing Key value"
             }
+            # Fail
             return make_response(jsonify(response_body), 400)
     elif request.method == 'GET':
         """Handles Get request"""
@@ -46,46 +48,60 @@ def api_parties():
                 "status": 200,
                 "data": parties
             }
+            # Successful
             return make_response(jsonify(response_body), 200)
         else:
             response_body = {
                 "status": 404,
                 "error": "404 ERROR:DATA NOT FOUND"
             }
+            # Unsuccessful
             return make_response(jsonify(response_body), 404)
 
 
-@version_1.route("/offices", methods=['POST'])
+@version_1.route("/offices", methods=['GET', 'POST'])
 def api_create_office():
-    """
-    Creates an office on  endpoint with POST response
-    :return: response depending on post request data
-    """
-    # get the office as json and save it in the model
-    office = request.get_json(force=True)
-    # Checks keys exist in given dict as sets
-    if {'type', 'name'} <= set(office):
-        # Create Office Model instance and add Party to list
-        gen_id = OfficesModel(office).create_government_office()
-        if gen_id:
-            # successful response
+    if request.method == 'POST':
+        """
+        Creates an office on /offices  endpoint with POST response
+        :return: response depending on post request data
+        """
+        # get the office as json and save it in the model
+        office = request.get_json(force=True)
+        # Checks keys exist in given dict as sets
+        if {'type', 'name'} <= set(office):
+            # Create Office Model instance and add Party to list
+            gen_id = OfficesModel(office).create_government_office()
+            if gen_id:
+                # successful response
+                response_body = {
+                    "status": 201,
+                    "data": [{
+                        "id": gen_id,
+                        "type": office['type'],
+                        "name": office['name']
+                    }]
+                }
+                # Successful
+                return make_response(jsonify(response_body), 201)
+        else:
+            # Missing data bad request response
+            # Fail response
             response_body = {
-                "status": 201,
-                "data": [{
-                    "id": gen_id,
-                    "type": office['type'],
-                    "name": office['name']
-                }]
+                "status": 400,
+                "error": "400 ERROR:BAD REQUEST,Missing Key value"
             }
-            return make_response(jsonify(response_body), 201)
-    else:
-        # Missing data bad request response
-        # Fail response
-        response_body = {
-            "status": 400,
-            "error": "400 ERROR:BAD REQUEST,Missing Key value"
-        }
-        return make_response(jsonify(response_body), 400)
+            # Unsuccessful
+            return make_response(jsonify(response_body), 400)
+    elif request.method == 'GET':
+        offices = OfficesModel().get_all_government_offices()
+        if len(offices) >= 0:
+            # If parties list has no items or does
+            response_body = {
+                "status": 200,
+                "data": offices
+            }
+            # Successful
+            return make_response(jsonify(response_body), 200)
 
-
-
+        return make_response(jsonify({"status": 404, "error": "404 ERROR:DATA NOT FOUND"}), 404)


### PR DESCRIPTION
### What Does This PR do?
- Adds Default Error Handler to 404 related errors
- Add Comment to base test class
- Refactor Tests for retrieving  all offices endpoint and error case
- Test for wrong path
- Refactored models to have an optional parameter in constructor and
  get all government offices in Offices Model
- Add response status code in error handler
### Description of Task To Be Completed?
Have The `GET /offices` Endpoint working for both success and error response
200 - Success
400 - Error
### How Can This Be Manually Tested 
**Test on Postman**
[![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/c1cdd9f5a74998056b51)
- Clone repository and git checkout to ft-user-view-office-163684270
**In Terminal**
- Start virtual environment `. {env nam}/bin/activate 
- export FLASK_APP=run.py
- export FLASK_ENV=development
- export FLASK_DEBUG=1
- flask run and copy the link and paste to Postman and append `/offices` endpoint
- Send Request and view reponse
- To view error response remove one of the fields from body
### Screenshots
![screenshot from 2019-02-07 02-03-22](https://user-images.githubusercontent.com/20339228/52380229-0c2c8180-2a7e-11e9-9061-a6a452a2523d.png)
![screenshot from 2019-02-07 02-04-09](https://user-images.githubusercontent.com/20339228/52380230-0cc51800-2a7e-11e9-9ada-24f0f8120584.png)

### Relevant PT Stories
#163684270