### PR TITLE
#163684271 View Specific Office REST Endpoint

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -8,7 +8,7 @@ from .v1.views import version_1
 # Error Handler Method
 def page_not_found(e):
     error_response = {
-        "error": "404 ERROR:PAGE NOT FOUND",
+        "error": "404 ERROR:REQUESTED DATA NOT FOUND",
         "status": 404
     }
     return make_response(jsonify(error_response), 404)

--- a/api/tests/__init__.py
+++ b/api/tests/__init__.py
@@ -21,6 +21,10 @@ class BaseTestCase(unittest.TestCase):
             "hqAddress": "Nairobi,Kenya 00100",
             "logoUrl": "https://www.some.url.co.ke"
         }
+        self.error_not_found = {
+            "error": "404 ERROR:REQUESTED DATA NOT FOUND",
+            "status": 404
+        }
 
     def tearDown(self):
         # Reset Data Structs after tests back to empty lists

--- a/api/tests/test_offices_endpoint.py
+++ b/api/tests/test_offices_endpoint.py
@@ -63,18 +63,36 @@ class OfficeEndpointsTestCase(BaseTestCase):
     def test_view_specific_office(self):
         """Tests GET Http method request on /office/{:id} endpoint"""
         # Post, add an office
-        # self.client.post('/offices', json=self.office)
-        # # Get data for specific office
-        # response = self.client.get('/offices/{0}'.format(self.office['id']))
-        # assert 200 == response.status, "Should Return a 200 HTTP Status Code:Success"
-        # # Returns Dict as string and compares if its in response
-        # assert json.dumps({'data': [self.office]}) in str(response.data)
-        pass
+        self.client.post('api/v1/offices', data=json.dumps(self.office))
+        # Get data for specific office
+        response = self.client.get('api/v1/offices/{}'.format(1))
+        expected_response = {
+            "id": 1,
+            "name": "Permanent Secretary",
+            "type": "Senior"
+        }
+        assert response.status_code == 200, "Should Return a 200 HTTP Status Code:Success"
+        # Returns Dict as string and compares if its in response
+        assert expected_response == response.json['data'][0]
+
+    def test_view_specific_office_invalid_id(self):
+        """Tests malformed GET Http method request on /office/{:id} endpoint"""
+        response = self.client.get('api/v1/offices/{}'.format(4578))
+        assert 404 == response.status_code, "Should Return a 404 HTTP Status Code Response:Not Found"
+        expected_response = {
+            "status": 404,
+            "error": "Invalid Id Not Found"
+        }
+        # Should return error message
+        assert expected_response == response.json, "Should return resource not found response"
 
     def test_view_specific_office_not_found(self):
         """Tests malformed GET Http method request on /office/{:id} endpoint"""
-        # response = self.client.get('/offices/45789')
-        # assert 404 == response.status, "Should Return a 404 HTTP Status Code Response:Not Found"
-        # # Should return error message
-        # assert "Not Found" in str(response.error), "Should return resource not found response"
-        pass
+        response = self.client.get('api/v1/offies/{}'.format(0))
+        assert 404 == response.status_code, "Should Return a 404 HTTP Status Code Response:Not Found"
+        expected_response = {
+            "status": 404,
+            "error": "404 ERROR:REQUESTED DATA NOT FOUND"
+        }
+        # Should return error message
+        assert expected_response == response.json, "Should return resource not found response"

--- a/api/tests/test_offices_endpoint.py
+++ b/api/tests/test_offices_endpoint.py
@@ -54,11 +54,7 @@ class OfficeEndpointsTestCase(BaseTestCase):
         response = self.client.get('api/v1/ofices')
         assert response.status_code == 404, "Should Return a 404 HTTP Status Code Response:Resource Not Found"
         # Should return error message
-        expected_json_resp = {
-            "error": "404 ERROR:PAGE NOT FOUND",
-            "status": 404
-        }
-        assert expected_json_resp == response.json
+        assert self.error_not_found == response.json
 
     def test_view_specific_office(self):
         """Tests GET Http method request on /office/{:id} endpoint"""
@@ -90,9 +86,5 @@ class OfficeEndpointsTestCase(BaseTestCase):
         """Tests malformed GET Http method request on /office/{:id} endpoint"""
         response = self.client.get('api/v1/offies/{}'.format(0))
         assert 404 == response.status_code, "Should Return a 404 HTTP Status Code Response:Not Found"
-        expected_response = {
-            "status": 404,
-            "error": "404 ERROR:REQUESTED DATA NOT FOUND"
-        }
         # Should return error message
-        assert expected_response == response.json, "Should return resource not found response"
+        assert self.error_not_found == response.json, "Should return resource not found response"

--- a/api/tests/test_parties_endpoint.py
+++ b/api/tests/test_parties_endpoint.py
@@ -46,7 +46,7 @@ class PartiesEndpointsTestCase(BaseTestCase):
         response = self.client.patch('/parties/{}/name'.format(1))
         assert response.status_code == 404, "Should Return a 404 HTTP Status Code Response:Not Found"
         # Should return error message
-        assert "404 ERROR" in response.json['error'], "Should return not found response"
+        assert self.error_not_found == response.json, "Should return not found response"
 
     def test_delete_political_party(self):
         """Tests DELETE Http method request on /parties/{:id} endpoint"""
@@ -120,9 +120,5 @@ class PartiesEndpointsTestCase(BaseTestCase):
         """Tests malformed GET Http method request on /parties/ endpoint"""
         response = self.client.get('api/v1/partis')
         assert response.status_code == 404, "Should Return a 404 HTTP Status Code Response:Resource Not Found"
-        expected_json_resp = {
-            "error": "404 ERROR:PAGE NOT FOUND",
-            "status": 404
-        }
         # Should return error message
-        assert expected_json_resp == response.json, "Should return not found Response"
+        assert self.error_not_found == response.json, "Should return not found Response"

--- a/api/v1/models.py
+++ b/api/v1/models.py
@@ -31,7 +31,7 @@ class PartiesModel:
         # Get List Of Parties
         return self.parties
 
-    def get_specific_political_party(self, party_id):
+    def get_specific_political_party_name(self, party_id):
         # Get party by passed in id and return party otherwise default to message response
         if party_id is not None:
             for party in parties:
@@ -41,9 +41,10 @@ class PartiesModel:
 
 
 class OfficesModel:
-    def __init__(self, office=None):
+    def __init__(self, office=None, office_id=None):
         self.offices = offices
         self.office = office
+        self.office_id = office_id
 
     def create_government_office(self):
         """A function that facilitates creation of a government office and appending to a data structure
@@ -64,4 +65,14 @@ class OfficesModel:
         return created_office['id']
 
     def get_all_government_offices(self):
+        # Gets List Of Government offices
         return self.offices
+
+    def get_specific_office(self, office_id):
+        # Gets Office after series of checks
+        if office_id >= 1:
+            for office in offices:
+                if office['id'] == office_id:
+                    return office
+                return 'Doesnt Exist'
+        return 'Invalid Id'

--- a/api/v1/views.py
+++ b/api/v1/views.py
@@ -108,8 +108,8 @@ def api_create_office():
 
 
 @version_1.route("/parties/<party_id>/name", methods=['PATCH'])
-def api_update(party_id):
-    model_result = PartiesModel().get_specific_political_party(int(party_id))
+def api_edit_party(party_id):
+    model_result = PartiesModel().get_specific_political_party_name(int(party_id))
     if 'Doesnt Exist' in model_result:
         return make_response(jsonify({"status": 404, "error": "Political Party Not Found"}), 404)
     else:
@@ -122,3 +122,19 @@ def api_update(party_id):
             "data": [{"id": party_id, "name": model_result}]
         }
         return make_response(jsonify(response_body), 200)
+
+
+@version_1.route("/offices/<office_id>", methods=['GET'])
+def api_specific_office(office_id):
+    model_result = OfficesModel().get_specific_office(int(office_id))
+    # Get Specific office data from model
+    if 'Doesnt Exist' in model_result:
+        return make_response(jsonify({"status": 404, "error": "Data Not Found"}), 404)
+    elif 'Invalid Id' in model_result:
+        return make_response(jsonify({"status": 404, "error": "Invalid Id Not Found"}), 404)
+    else:
+        response_body = {
+            "status": 200,
+            "data": [model_result]
+        }
+    return make_response(jsonify(response_body), 200)


### PR DESCRIPTION
### What does this PR do?
- Refactored Tests to Test 3 Cases success,invalid id and wrong resource
- In models created function in office model to return office and renamed
function in PartiesModel to be more specific
- Added Route to specific office in view
- Refactored Error Response for 404
- Refactored Tests adhere to OOP
### Description of Task To Be Completed?
Have The `GET /offices/<office-id>` Endpoint working for both success and error response
200 - Success
404 - Error
### How Can This Be Manually Tested 
**Test on Postman**
[![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/da9a9724b313dd7e81e8)
- Clone repository and git checkout to ft-create-party-163684260
* In Terminal*
- Start virtual environment `. {env nam}/bin/activate 
- export FLASK_APP=run.py
- export FLASK_ENV=development
- export FLASK_DEBUG=1
- flask run and copy link and paste to Postman and run POST Request on `/offices endpoint`
- Under body section create a raw json request
`{
   "type":"officetype",
   "name":"name",
}`
- append `/offices/<office-id>` endpoint and add id of generated office
- Send Request and view reponse
- To view error remove one of the fields from body or input incorrect id
### Screenshots
![screenshot from 2019-02-07 10-32-00](https://user-images.githubusercontent.com/20339228/52397051-0312d300-2ac5-11e9-88fb-b6f94b6dbf07.png)
![screenshot from 2019-02-07 10-35-23](https://user-images.githubusercontent.com/20339228/52397053-03ab6980-2ac5-11e9-9ba7-b045bc3dc306.png)
### Relevant PT Stories
_#163684271_
