### PR TITLE
#163684269 Get Specific Party Endpoint

### DIFF
--- a/api/tests/__init__.py
+++ b/api/tests/__init__.py
@@ -25,6 +25,10 @@ class BaseTestCase(unittest.TestCase):
             "error": "404 ERROR:REQUESTED DATA NOT FOUND",
             "status": 404
         }
+        self.invalid_id_json = {
+            "status": 404,
+            "error": "Invalid Id Not Found"
+        }
 
     def tearDown(self):
         # Reset Data Structs after tests back to empty lists

--- a/api/tests/test_offices_endpoint.py
+++ b/api/tests/test_offices_endpoint.py
@@ -75,12 +75,8 @@ class OfficeEndpointsTestCase(BaseTestCase):
         """Tests malformed GET Http method request on /office/{:id} endpoint"""
         response = self.client.get('api/v1/offices/{}'.format(4578))
         assert 404 == response.status_code, "Should Return a 404 HTTP Status Code Response:Not Found"
-        expected_response = {
-            "status": 404,
-            "error": "Invalid Id Not Found"
-        }
         # Should return error message
-        assert expected_response == response.json, "Should return resource not found response"
+        assert self.invalid_id_json == response.json, "Should return resource not found response"
 
     def test_view_specific_office_not_found(self):
         """Tests malformed GET Http method request on /office/{:id} endpoint"""

--- a/api/tests/test_parties_endpoint.py
+++ b/api/tests/test_parties_endpoint.py
@@ -69,21 +69,32 @@ class PartiesEndpointsTestCase(BaseTestCase):
     def test_view_political_party(self):
         """Tests GET Http method request on /parties/{:id} endpoint"""
         # Create Party First
-        # resp = self.client.post('api/v1/parties', json=self.party, content_type='application/json')
-        # print(resp.json['data'][''])
-        # # Get data for specific office
-        # response = self.client.get('/offices/{0}'.format(self.party['id']))
-        # assert 200 == response.status, "Should Return a 200 HTTP Status Code:Success"
-        # # Returns Dict as string and compares if its in response
-        # assert json.dumps({'data': [self.party]}) in str(response.data)
-        pass
+        self.client.post('api/v1/parties', data=json.dumps(self.party))
+        # Get data for specific party
+        response = self.client.get('api/v1/parties/{0}'.format(1))
+        expected_response = {
+            "id": 1,
+            "name": "Pinnacle Party",
+            "hqAddress": "Nairobi,Kenya 00100",
+            "logoUrl": "https://www.some.url.co.ke"
+        }
+        assert response.status_code == 200, "Should Return a 200 HTTP Status Code:Success"
+        # Returns Dict as string and compares if its in response
+        assert expected_response == response.json['data'][0]
 
-    def test_view_political_party_not_found(self):
+    def test_view_political_party_invalid_id(self):
         """Tests malformed GET Http method request on /parties/{:id} endpoint"""
-        # response = self.client.get('/parties/45789')
-        # assert 404 == response.status, "Should Return a 404 HTTP Status Code Response:Not Found"
-        # # Should return error message
-        # assert "Not Found" in str(response.error), "Should return resource not found response"
+        response = self.client.get('api/v1/parties/{}'.format(0))
+        assert response.status_code == 404, "Should Return a 404 HTTP Status Code Response:Not Found"
+        # Should return error message
+        assert self.invalid_id_json == response.json, "Should return resource not found response"
+
+    def test_view_specific_office_not_found(self):
+        """Tests malformed GET Http method request on /office/{:id} endpoint"""
+        response = self.client.get('api/v1/partiess/{}'.format(0))
+        assert 404 == response.status_code, "Should Return a 404 HTTP Status Code Response:Not Found"
+        # Should return error message
+        assert self.error_not_found == response.json, "Should return resource not found response"
 
     def test_view_all_political_parties(self):
         """Tests GET Http method request on /parties/ endpoint"""

--- a/api/v1/models.py
+++ b/api/v1/models.py
@@ -39,6 +39,15 @@ class PartiesModel:
                     return party['name']
         return 'Doesnt Exist In Model'
 
+    def get_specific_party(self, party_id):
+        # Gets Office after series of checks
+        if party_id >= 1:
+            for party in parties:
+                if party['id'] == party_id:
+                    return party
+                return 'Doesnt Exist'
+        return 'Invalid Id'
+
 
 class OfficesModel:
     def __init__(self, office=None, office_id=None):

--- a/api/v1/views.py
+++ b/api/v1/views.py
@@ -60,7 +60,7 @@ def api_parties():
 
 
 @version_1.route("/offices", methods=['GET', 'POST'])
-def api_create_office():
+def api_office():
     if request.method == 'POST':
         """
         Creates an office on /offices  endpoint with POST response
@@ -127,7 +127,21 @@ def api_edit_party(party_id):
 @version_1.route("/offices/<office_id>", methods=['GET'])
 def api_specific_office(office_id):
     model_result = OfficesModel().get_specific_office(int(office_id))
-    # Get Specific office data from model
+    if 'Doesnt Exist' in model_result:
+        return make_response(jsonify({"status": 404, "error": "Data Not Found"}), 404)
+    elif 'Invalid Id' in model_result:
+        return make_response(jsonify({"status": 404, "error": "Invalid Id Not Found"}), 404)
+    else:
+        response_body = {
+            "status": 200,
+            "data": [model_result]
+        }
+    return make_response(jsonify(response_body), 200)
+
+
+@version_1.route("/parties/<parties_id>", methods=['GET'])
+def api_specific_party(parties_id):
+    model_result = PartiesModel().get_specific_party(int(parties_id))
     if 'Doesnt Exist' in model_result:
         return make_response(jsonify({"status": 404, "error": "Data Not Found"}), 404)
     elif 'Invalid Id' in model_result:


### PR DESCRIPTION
### What does this PR do?
- Refactored Tests to pass
- Created method in model to retrieve data from list
- Added Route to View Specific Party
### Description of Task To Be Completed?
Have The `GET /parties/<party_id>` Endpoint working for both success and error response
200 - Success
404 - Error not found
### How Can This Be Manually Tested 
**Test on Postman**
[![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/78ea3551331d5a20f310)
- Clone repository and git checkout to ft-view-specific-party-163684269
**In Terminal**
- Start virtual environment `. {env nam}/bin/activate 
- export FLASK_APP=run.py
- export FLASK_ENV=development
- export FLASK_DEBUG=1
- flask run and copy link and paste to Postman and append `/parties` endpoint
- Select POST request and create a party using the below body section create a raw json request
`{
   "name":"name",
   "hqAddress":"hqAddress",
"logoUrl":"logo"
}`
- Send Request and select `GET ` Method to query created party by using `/parties/<id_generated>`
- To view error remove one of the fields from body or alter endpoint
### Screenshots
![screenshot from 2019-02-07 12-26-44](https://user-images.githubusercontent.com/20339228/52402042-4fb1da80-2ad4-11e9-8011-87ebcf1160db.png)
