### PR TITLE
#164035303 Delete Office Endpoint

### DIFF
--- a/.env
+++ b/.env
@@ -3,7 +3,7 @@
 #Run instance of app
 export FLASK_APP='run.py'
 #environment config
-export FLASK_ENV='testing'
+export FLASK_ENV='development'
 export TESTING_DATABASE_URI=''
-export DEVELOPMENT_DATABASE_URI=''
+export DEVELOPMENT_DATABASE_URI='postgresql://postgres:politico_dev@localhost:5432/politico_db_development'
 export PRODUCTION_DATABASE_URI=''

--- a/.env
+++ b/.env
@@ -2,10 +2,8 @@
 . venv/bin/activate
 #Run instance of app
 export FLASK_APP='run.py'
-#environment config -manually configured
-export FLASK_ENV='development'
-
-#database uris as per config
-
+#environment config
+export FLASK_ENV='testing'
+export TESTING_DATABASE_URI=''
 export DEVELOPMENT_DATABASE_URI=''
 export PRODUCTION_DATABASE_URI=''

--- a/.env
+++ b/.env
@@ -5,5 +5,5 @@ export FLASK_APP='run.py'
 #environment config
 export FLASK_ENV='development'
 export TESTING_DATABASE_URI=''
-export DEVELOPMENT_DATABASE_URI='postgresql://postgres:politico_dev@localhost:5432/politico_db_development'
+export DEVELOPMENT_DATABASE_URI=''
 export PRODUCTION_DATABASE_URI=''

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ install:
 before_script:
   - psql -c 'create database politico_db_tests;' -U postgres
   - export FLASK_ENV=testing
+  - export TESTING_DATABASE_URI="postgresql://postgres@localhost:5432/politico_db_tests"
 script:
   - pytest  --cov api tests  -v --cov-report term-missing
 after_success:

--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@ petitioning,voting and user login and sign up to be consumed by front end framew
 !['PythonVersion''](https://img.shields.io/badge/python-3.6.7-yellow.svg)
 !['License'](https://img.shields.io/badge/License-MIT-green.svg)
 !['Travis'](https://travis-ci.org/Davidodari/POLITICO-API.svg?branch=develop)
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/3d4db0349f554fdfa87359e1eee2cd06)](https://app.codacy.com/app/Davidodari/POLITICO-API?utm_source=github.com&utm_medium=referral&utm_content=Davidodari/POLITICO-API&utm_campaign=Badge_Grade_Dashboard)
-[![Maintainability](https://api.codeclimate.com/v1/badges/4151dd7acdb2ddb19f1f/maintainability)](https://codeclimate.com/github/Davidodari/POLITICO-API/maintainability)
 [![Coverage Status](https://coveralls.io/repos/github/Davidodari/POLITICO-API/badge.svg?branch=ch-refactor-tests-163807952)](https://coveralls.io/github/Davidodari/POLITICO-API?branch=ch-refactor-tests-163807952)
 
 ### Endpoints

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -29,8 +29,8 @@ def method_not_allowed(e):
     return make_response(jsonify(error_response), 405)
 
 
-# configure app prerequisites testing default
-def create_app(configuration='testing'):
+# configure app prerequisites
+def create_app(configuration='development'):
     # create and configure the app
     app = Flask(__name__, instance_relative_config=True)
     app.config.from_object(application_config[configuration])

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -29,8 +29,8 @@ def method_not_allowed(e):
     return make_response(jsonify(error_response), 405)
 
 
-# configure app prerequisites
-def create_app(configuration='development'):
+# configure app prerequisites testing default
+def create_app(configuration='testing'):
     # create and configure the app
     app = Flask(__name__, instance_relative_config=True)
     app.config.from_object(application_config[configuration])

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -40,7 +40,6 @@ def create_app(configuration='development'):
     app.register_blueprint(party_api)
     app.register_blueprint(office_api)
     # Register app blue prints version 2
-    drop_tables()
     create_tables()
     app.register_blueprint(user_api_v2)
     app.register_blueprint(office_api_v2)

--- a/api/v1/views/user_view.py
+++ b/api/v1/views/user_view.py
@@ -7,15 +7,12 @@ user_api = Blueprint('user_v1', __name__, url_prefix="/api/v1")
 @user_api.route("/users", methods=['POST'])
 def api_user_sign_up():
     user = request.get_json(force=True)
-    # Make Sure Keys Exist
     if {"firstname", "lastname", "othername", "email", "phoneNumber", "passportUrl", "password"} <= set(
             user):
         validated_user_msg = UserModel(user=user).user_sign_up()
         if 'Invalid Data' in validated_user_msg:
-            # Invalidated data
             return make_response(jsonify({"status": 400, "error": "Parsing Invalid Data ,Bad Request"}), 400)
         elif 'User Exists' in validated_user_msg:
-            # Duplicate User not allowed
             return make_response(jsonify({"status": 409, "error": "User Already Exists"}), 409)
         else:
             return make_response(

--- a/api/v2/models/office_model.py
+++ b/api/v2/models/office_model.py
@@ -7,21 +7,17 @@ class OfficesModelDb:
     """Offices Model Class"""
 
     def __init__(self, office=None, office_id=None):
-        # Setup connection to db
         self.db_conn = db_connect()
-        # Office object being worked on
         self.office = office
         self.office_id = office_id
 
     def create_office(self):
         """Function to create an office in db"""
-        # Passed to validator
         validated_office = OfficeValidator(self.office).all_checks()
         if 'Invalid' in validated_office:
             return 'Invalid Data'
         office_type = validated_office['type']
         office_name = validated_office['name']
-        # Add Office to table
         data = (office_type, office_name)
         query = "INSERT INTO offices (office_type,office_name) " \
                 "VALUES(%s,%s);"
@@ -54,16 +50,19 @@ class OfficesModelDb:
         return results
 
     def edit_office(self, new_name):
-        # TODO update office type
         if isinstance(self.office_id, int):
             query = "UPDATE offices SET office_name = %s WHERE _id = %s;"
             cursor = self.db_conn.cursor()
-            # Validate data to be updated
-            if len(new_name) < 4 or isinstance(new_name, str) == False:
+            if len(new_name) < 4 or isinstance(new_name, str) is False:
                 return 'Invalid Data'
-            # Execute function works with iterable
             try:
-                # Cant put existing data when editing
+                # Check name doesnt exist first
+                query_check = "SELECT * FROM offices WHERE office_name=%s"
+                cursor.execute(query_check, (new_name,))
+                self.db_conn.commit()
+                row = cursor.fetchall()
+                if len(row) > 0:
+                    return 'Office Exists'
                 cursor.execute(query, (new_name, self.office_id,))
                 self.db_conn.commit()
             except psycopg2.IntegrityError:
@@ -71,8 +70,8 @@ class OfficesModelDb:
             # Look Up To Confirm was saved
             query = "SELECT * FROM offices WHERE _id=%s"
             cursor.execute(query, (self.office_id,))
-            office_row = cursor.fetchall()
-            return office_row
+            row = cursor.fetchall()
+            return row
         return 'Invalid Id'
 
     def delete_office(self):

--- a/api/v2/models/office_model.py
+++ b/api/v2/models/office_model.py
@@ -40,7 +40,18 @@ class OfficesModelDb:
         self.db_conn.commit()
         # Result of tables in list as tuples
         rows = cursor.fetchall()
-        return rows
+        results = []
+        for row in rows:
+            id = row[0]
+            type = row[1]
+            name = row[2]
+            office = {
+                "id": id,
+                "type": type,
+                "name": name
+            }
+            results.append(office)
+        return results
 
     def edit_office(self, new_name):
         # TODO update office type

--- a/api/v2/models/office_model.py
+++ b/api/v2/models/office_model.py
@@ -43,6 +43,7 @@ class OfficesModelDb:
         return rows
 
     def edit_office(self, new_name):
+        # TODO update office type
         if isinstance(self.office_id, int):
             query = "UPDATE offices SET office_name = %s WHERE _id = %s;"
             cursor = self.db_conn.cursor()
@@ -64,7 +65,17 @@ class OfficesModelDb:
         return 'Invalid Id'
 
     def delete_office(self):
-        pass
+        """Deletes an office from db"""
+        query = """DELETE FROM offices WHERE _id=%s RETURNING office_name"""
+        cursor = self.db_conn.cursor()
+        if isinstance(self.office_id, int):
+            cursor.execute(query, (self.office_id,))
+            self.db_conn.commit()
+            office_row = cursor.fetchall()
+            if len(office_row) == 0:
+                return 'Empty'
+            return office_row
+        return 'Invalid Id'
 
     def get_specific_office(self):
         """Gets a specific office provided by id"""

--- a/api/v2/models/office_model.py
+++ b/api/v2/models/office_model.py
@@ -38,13 +38,13 @@ class OfficesModelDb:
         rows = cursor.fetchall()
         results = []
         for row in rows:
-            id = row[0]
-            type = row[1]
-            name = row[2]
+            _id = row[0]
+            office_type = row[1]
+            office_name = row[2]
             office = {
-                "id": id,
-                "type": type,
-                "name": name
+                "id": _id,
+                "type": office_type,
+                "name": office_name
             }
             results.append(office)
         return results

--- a/api/v2/models/office_model.py
+++ b/api/v2/models/office_model.py
@@ -34,7 +34,6 @@ class OfficesModelDb:
         cursor = self.db_conn.cursor()
         cursor.execute(query)
         self.db_conn.commit()
-        # Result of tables in list as tuples
         rows = cursor.fetchall()
         results = []
         for row in rows:
@@ -56,7 +55,6 @@ class OfficesModelDb:
             if len(new_name) < 4 or isinstance(new_name, str) is False:
                 return 'Invalid Data'
             try:
-                # Check name doesnt exist first
                 query_check = "SELECT * FROM offices WHERE office_name=%s"
                 cursor.execute(query_check, (new_name,))
                 self.db_conn.commit()
@@ -67,7 +65,6 @@ class OfficesModelDb:
                 self.db_conn.commit()
             except psycopg2.IntegrityError:
                 return 'Office Exists'
-            # Look Up To Confirm was saved
             query = "SELECT * FROM offices WHERE _id=%s"
             cursor.execute(query, (self.office_id,))
             row = cursor.fetchall()

--- a/api/v2/models/office_model.py
+++ b/api/v2/models/office_model.py
@@ -71,6 +71,8 @@ class OfficesModelDb:
             query = "SELECT * FROM offices WHERE _id=%s"
             cursor.execute(query, (self.office_id,))
             row = cursor.fetchall()
+            if len(row) == 0:
+                return 'Invalid Id'
             return row
         return 'Invalid Id'
 

--- a/api/v2/views/office_view.py
+++ b/api/v2/views/office_view.py
@@ -40,7 +40,7 @@ def api_edit_office(offices_id):
             return make_response(jsonify({"status": 400, "error": "Invalid Data ,Check id or data being updated"}), 400)
         elif 'Office Exists' in model_result:
             return make_response(jsonify({"status": 409, "error": "Office with similar name exists"}), 409)
-        return make_response(jsonify({"status": 200, "message": "Updated succesfully"}), 200)
+        return make_response(jsonify({"status": 200, "message": "Updated successfully"}), 200)
     return make_response(jsonify({"status": 400, "error": "Missing Key value"}), 400)
 
 

--- a/api/v2/views/office_view.py
+++ b/api/v2/views/office_view.py
@@ -58,13 +58,22 @@ def api_edit_office(offices_id):
 def api_specific_office_get(office_id):
     oid = id_conversion(office_id)
     office = OfficesModelDb(office_id=oid).get_specific_office()
-    if isinstance(office, list) and len(office) > 1:
+    if isinstance(office, list) and len(office) >= 1:
         response_body = {
             "id": office[0][0],
             "office_type": office[0][1],
             "office_name": office[0][2]
         }
         return make_response(jsonify({"status": 200, "data": [response_body]}), 200)
+    return make_response(jsonify({"status": 404, "error": "Data Not Found"}), 404)
+
+
+@office_api_v2.route("/offices/<office_id>", methods=['DELETE'])
+def api_specific_office_delete(office_id):
+    oid = id_conversion(office_id)
+    office = OfficesModelDb(office_id=oid).delete_office()
+    if isinstance(office, list):
+        return make_response(jsonify({"status": 200, "message": "{} Deleted".format(office[0][0])}), 200)
     return make_response(jsonify({"status": 404, "error": "Data Not Found"}), 404)
 
 

--- a/api/v2/views/office_view.py
+++ b/api/v2/views/office_view.py
@@ -40,7 +40,7 @@ def api_edit_office(offices_id):
             return make_response(jsonify({"status": 400, "error": "Invalid Data ,Check id or data being updated"}), 400)
         elif 'Office Exists' in model_result:
             return make_response(jsonify({"status": 409, "error": "Office with similar name exists"}), 409)
-        return make_response(jsonify({"status": 200, "message": "{} updated succesfully".format(model_result)}), 200)
+        return make_response(jsonify({"status": 200, "message": "Updated succesfully"}), 200)
     return make_response(jsonify({"status": 400, "error": "Missing Key value"}), 400)
 
 

--- a/api/v2/views/office_view.py
+++ b/api/v2/views/office_view.py
@@ -58,7 +58,7 @@ def api_edit_office(offices_id):
 def api_specific_office_get(office_id):
     oid = id_conversion(office_id)
     office = OfficesModelDb(office_id=oid).get_specific_office()
-    if isinstance(office, list):
+    if isinstance(office, list) and len(office) > 1:
         response_body = {
             "id": office[0][0],
             "office_type": office[0][1],

--- a/api/v2/views/office_view.py
+++ b/api/v2/views/office_view.py
@@ -6,45 +6,35 @@ office_api_v2 = Blueprint('office_v2', __name__, url_prefix="/api/v2")
 
 @office_api_v2.route("/offices", methods=['POST'])
 def api_create_office():
-    # get the office as json
     office = request.get_json(force=True)
     # Checks keys exist in given dict as sets
     if {'type', 'name'} <= set(office):
-        # add office to model which returns generated id
         office_name = OfficesModelDb(office).create_office()
         if 'Office Exists' in office_name:
-            # Duplicate Office not allowed
             return make_response(jsonify({"status": 409, "error": "Office Already Exists"}), 409)
         elif 'Invalid Data' in office_name:
-            # Invalid Data
             return make_response(jsonify({"status": 400, "error": "Check Input Values"}), 400)
-
         response_body = {
             "status": 201,
             "data": [{
                 "name": office_name
             }]
         }
-        # Successful
         return make_response(jsonify(response_body), 201)
-    # Missing Keys
     return make_response(jsonify({"status": 400, "error": "Missing Key value"}), 400)
 
 
 @office_api_v2.route("/offices", methods=['GET'])
 def api_get_offices():
     offices = OfficesModelDb().get_all_offices()
-    # If parties list has no items or does  Successful
     return make_response(jsonify({"status": 200, "data": offices}), 200)
 
 
 @office_api_v2.route("/offices/<offices_id>/name", methods=['PATCH'])
 def api_edit_office(offices_id):
-    # Get Json Request Data
     oid = id_conversion(offices_id)
     updated_office_data = request.get_json(force=True)
     if {'name'} <= set(updated_office_data):
-        # Pass in office id and office data to be used
         model_result = OfficesModelDb(office_id=oid).edit_office(updated_office_data['name'])
         if 'Invalid Id' in model_result or 'Invalid Data' in model_result:
             return make_response(jsonify({"status": 400, "error": "Invalid Data ,Check id or data being updated"}), 400)
@@ -82,5 +72,4 @@ def id_conversion(item_id):
         oid = int(item_id)
         return oid
     except ValueError:
-        # Use of Letters as ids edge case
         return 'Invalid'

--- a/api/v2/views/user_view.py
+++ b/api/v2/views/user_view.py
@@ -20,7 +20,7 @@ def api_user_sign_up():
         else:
             return make_response(
                 jsonify({"status": 201, "data": "{} Signed Up Successfully".format(validated_user)}), 201)
-    #     Missing data
+    # Missing data
     return make_response(jsonify({"status": 400, "error": "Invalid Request ,Missing Data"}), 400)
 
 

--- a/instance/config.py
+++ b/instance/config.py
@@ -11,7 +11,7 @@ class TestingConfig(Config):
     TESTING = True
     DEBUG = True
     # Testing db accessed explicitly
-    DATABASE_URI = "postgresql://postgres:politico_dev@localhost:5432/politico_db_tests"
+    DATABASE_URI = os.getenv("TESTING_DATABASE_URI")
 
 
 class ProductionConfig(Config):

--- a/tests/v2tests/__init__.py
+++ b/tests/v2tests/__init__.py
@@ -1,6 +1,6 @@
 import unittest
 # Imports create app function to set testing config
-from run import app_context
+from run import create_app
 # from api.db_conn import execute_drop_queries
 from api.v2.models.user_model import UserModelDb
 from api.v2.models.office_model import OfficesModelDb
@@ -13,7 +13,7 @@ class BaseTestCase(unittest.TestCase):
         drop_tables()
         create_tables()
         # setup flask app instance to testing configuration environment
-        self.app = app_context()
+        self.app = create_app('testing')
         # drop existing tables
         self.client = self.app.test_client()
         self.user = UserModelDb(

--- a/tests/v2tests/__init__.py
+++ b/tests/v2tests/__init__.py
@@ -8,13 +8,10 @@ from api.db_conn import create_tables, drop_tables, close_connection
 
 
 class BaseTestCase(unittest.TestCase):
-    # Base Class for v2 test files
     def setUp(self):
         drop_tables()
         create_tables()
-        # setup flask app instance to testing configuration environment
         self.app = create_app('testing')
-        # drop existing tables
         self.client = self.app.test_client()
         self.user = UserModelDb(
             user={"firstname": "David",
@@ -39,6 +36,5 @@ class BaseTestCase(unittest.TestCase):
         self.office_invalid = OfficesModelDb({"type": "Transport", "name": ""})
 
     def tearDown(self):
-        # execute_drop_queries()
         drop_tables()
         close_connection()

--- a/tests/v2tests/test_office_model_db.py
+++ b/tests/v2tests/test_office_model_db.py
@@ -63,3 +63,14 @@ class OfficeModelDbTestCase(BaseTestCase):
         """Tests cant get data with invalid id"""
         office = OfficesModelDb(office_id='t').get_specific_office()
         self.assertIn('Invalid Id', office)
+
+    def test_delete_office_success(self):
+        """Tests User cant input existing office name"""
+        OfficesModelDb({"name": "Governor", "type": "Government"}).create_office()
+        delete_office = OfficesModelDb(office_id=1).delete_office()
+        self.assertEqual('Governor', delete_office[0][0])
+
+    def test_delete_office_failure(self):
+        """Tests User cant input existing office name"""
+        delete_office = OfficesModelDb(office_id='e').delete_office()
+        self.assertEqual('Invalid Id', delete_office)

--- a/tests/v2tests/test_office_view_db.py
+++ b/tests/v2tests/test_office_view_db.py
@@ -132,7 +132,15 @@ class OfficeEndpointsTestCase(BaseTestCase):
         self.assertIn('Data Not Found', response.json['error'])
 
     def test_delete_item_success(self):
-        pass
+        self.client.post('api/v2/offices', data=json.dumps({
+            "name": "Government Steward",
+            "type": "Patrol"
+        }))
+        response = self.client.delete("api/v2/offices/1")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual('Government Steward Deleted', response.json['message'])
 
     def test_delete_item_fail(self):
-        pass
+        response = self.client.delete("api/v2/offices/1")
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual('Data Not Found', response.json['error'])

--- a/tests/v2tests/test_office_view_db.py
+++ b/tests/v2tests/test_office_view_db.py
@@ -76,7 +76,7 @@ class OfficeEndpointsTestCase(BaseTestCase):
             "name": "President"
         }))
         self.assertEqual(response.status_code, 200)
-        self.assertIn('President', response.json['message'])
+        self.assertIn('Updated Successfully', response.json['message'])
 
     def test_office_edited_unsuccessful_missing_key(self):
         response = self.client.patch('api/v2/offices/{}/name'.format(1), data=json.dumps({

--- a/tests/v2tests/test_office_view_db.py
+++ b/tests/v2tests/test_office_view_db.py
@@ -3,7 +3,7 @@ import json
 
 
 class OfficeEndpointsTestCase(BaseTestCase):
-    def test_office_created_success(self):
+    def test_office_creation_success(self):
         """
         Tests Office Created Successfully
         """
@@ -38,7 +38,7 @@ class OfficeEndpointsTestCase(BaseTestCase):
 
     def test_create_office_with_missing_data(self):
         """
-        Tests User Signed Up with missing
+        Tests create office with missing data
         """
         response = self.client.post('api/v2/offices', data=json.dumps({
             "name": "Attorney General"
@@ -46,13 +46,13 @@ class OfficeEndpointsTestCase(BaseTestCase):
         self.assertEqual(response.status_code, 400, "Should be Parsing Invalid Data ,Bad Request")
         self.assertIn('Missing Key value', response.json['error'])
 
-    def test_get_all_offices_empty(self):
+    def test_get_all_offices_empty_set(self):
         """Tests that the offices in the db are retrived as empty list if none"""
         response = self.client.get('api/v2/offices')
         self.assertEqual(response.status_code, 200, "Should be getting all offices")
         self.assertEqual(0, len(response.json['data']))
 
-    def test_get_all_offices(self):
+    def test_get_all_offices_success(self):
         """Tests that all offices are retrieved """
         self.client.post('api/v2/offices', data=json.dumps({
             "name": "Goverment Official",
@@ -68,7 +68,6 @@ class OfficeEndpointsTestCase(BaseTestCase):
 
     def test_office_edited_successfully(self):
         """"Tests that offices are edited successfully"""
-        # TODO From here
         self.client.post('api/v2/offices', data=json.dumps({
             "name": "Government Steward",
             "type": "Patrol"
@@ -86,7 +85,6 @@ class OfficeEndpointsTestCase(BaseTestCase):
         self.assertIn('Missing Key value', response.json['error'])
 
     def test_office_edited_exists(self):
-        # TODO fix
         self.client.post('api/v2/offices', data=json.dumps({
             "name": "Government Steward",
             "type": "Patrol"
@@ -121,17 +119,17 @@ class OfficeEndpointsTestCase(BaseTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn('Government Steward', response.json['data'][0]['office_name'])
 
-    def test_specific_office_unsuccessful(self):
+    def test_get_non_existing_office(self):
         response = self.client.get("api/v2/offices/1")
         self.assertEqual(response.status_code, 404)
         self.assertIn('Data Not Found', response.json['error'])
 
-    def test_specific_office_fail(self):
+    def test_get_office_with_invalid_id(self):
         response = self.client.get("api/v2/offices/---")
         self.assertEqual(response.status_code, 404)
         self.assertIn('Data Not Found', response.json['error'])
 
-    def test_delete_item_success(self):
+    def test_delete_office_success(self):
         self.client.post('api/v2/offices', data=json.dumps({
             "name": "Government Steward",
             "type": "Patrol"

--- a/tests/v2tests/test_office_view_db.py
+++ b/tests/v2tests/test_office_view_db.py
@@ -112,7 +112,7 @@ class OfficeEndpointsTestCase(BaseTestCase):
         self.assertEqual(response.status_code, 400)
         self.assertIn('Invalid Data ,Check id or data being updated', response.json['error'])
 
-    def test_specific_item_success(self):
+    def test_specific_office_success(self):
         self.client.post('api/v2/offices', data=json.dumps({
             "name": "Government Steward",
             "type": "Patrol"
@@ -121,7 +121,18 @@ class OfficeEndpointsTestCase(BaseTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn('Government Steward', response.json['data'][0]['office_name'])
 
-    def test_specific_item_fail(self):
+    def test_specific_office_unsuccessful(self):
+        response = self.client.get("api/v2/offices/1")
+        self.assertEqual(response.status_code, 404)
+        self.assertIn('Data Not Found', response.json['error'])
+
+    def test_specific_office_fail(self):
         response = self.client.get("api/v2/offices/---")
         self.assertEqual(response.status_code, 404)
         self.assertIn('Data Not Found', response.json['error'])
+
+    def test_delete_item_success(self):
+        pass
+
+    def test_delete_item_fail(self):
+        pass

--- a/tests/v2tests/test_office_view_db.py
+++ b/tests/v2tests/test_office_view_db.py
@@ -76,7 +76,7 @@ class OfficeEndpointsTestCase(BaseTestCase):
             "name": "President"
         }))
         self.assertEqual(response.status_code, 200)
-        self.assertIn('Updated Successfully', response.json['message'])
+        self.assertIn('Updated successfully', response.json['message'])
 
     def test_office_edited_unsuccessful_missing_key(self):
         response = self.client.patch('api/v2/offices/{}/name'.format(1), data=json.dumps({


### PR DESCRIPTION
### What does this PR do?
- Adds Delete Office Route with persistence to a database
- Configures env file to pick DB depending on env
- Adds tests for delete office endpoint

### Description of Task To Be Completed?
Have the DELETE method working on `/offices/office_id` endpoint working for both success and error cases
### How can this be manually tested?
- Clone the repo and checkout to bg-office-persistence-164035303
- Ensure db server is installed and in the env paste URIs that point to your db
- start the flask app using flask run and run on an api testing client to observe persistence with db
### Relevant Pivotal Tracker Stories?
[#164035303](https://www.pivotaltracker.com/n/projects/2241897)
### Screenshots
##### Deleting Office Process
1. Create Party
![screenshot from 2019-02-19 11-52-27](https://user-images.githubusercontent.com/20339228/53002293-6f82c000-343d-11e9-9914-f51723d229cb.png)
2. Delete Party
![screenshot from 2019-02-19 11-53-49](https://user-images.githubusercontent.com/20339228/53002311-7dd0dc00-343d-11e9-92e7-ee78e1edfa84.png)
3. Confirm List Of Party that it doesnt exist
![screenshot from 2019-02-19 11-53-59](https://user-images.githubusercontent.com/20339228/53002338-8de8bb80-343d-11e9-8695-b3da31e01060.png)

